### PR TITLE
Call indirect overlong support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,11 @@ bulk = []
 # Multi-value
 # https://github.com/WebAssembly/multi-value/
 multi_value = []
+
+# Call-indirect-overlong
+# A subset of the reference-types feature that contains just the
+# change to the call_indirect instruction encoding to change the
+# zero byte to an LEB encoding which may have an overlong encoding.
+# https://github.com/WebAssembly/reference-types/
+# https://github.com/WebAssembly/tool-conventions/blob/main/Lime.md
+call_indirect_overlong = []

--- a/src/elements/func.rs
+++ b/src/elements/func.rs
@@ -154,8 +154,7 @@ impl Serialize for FuncBody {
 		let mut counted_writer = CountedWriter::new(writer);
 
 		let data = self.locals;
-		let counted_list =
-			CountedListWriter::<Local, _>(data.len(), data.into_iter());
+		let counted_list = CountedListWriter::<Local, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 
 		let code = self.instructions;

--- a/src/elements/func.rs
+++ b/src/elements/func.rs
@@ -155,7 +155,7 @@ impl Serialize for FuncBody {
 
 		let data = self.locals;
 		let counted_list =
-			CountedListWriter::<Local, _>(data.len(), data.into_iter().map(Into::into));
+			CountedListWriter::<Local, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 
 		let code = self.instructions;

--- a/src/elements/primitives.rs
+++ b/src/elements/primitives.rs
@@ -42,25 +42,22 @@ impl TryFrom<usize> for VarUint32 {
 }
 
 impl VarUint32 {
-    /// Deserialize a LEB128‐encoded u32 with the leading byte already having been read.
-	pub fn deserialize_with_first<R: io::Read>(
-		reader: &mut R,
-		byte: u8,
-	) -> Result<Self, Error> {
+	/// Deserialize a LEB128‐encoded u32 with the leading byte already having been read.
+	pub fn deserialize_with_first<R: io::Read>(reader: &mut R, byte: u8) -> Result<Self, Error> {
 		let mut result = (byte & 0x7F) as u32;
-        let mut shift = 7;
-        loop {
-            let byte: u8 = Uint8::deserialize(reader)?.into();
-            result |= ((byte & 0x7F) as u32) << shift;
-            if shift >= 25 && (byte >> (32 - shift)) != 0 {
-                return Err(Error::InvalidVarUint32);
-            }
-            shift += 7;
-            if (byte & 0x80) == 0 {
-                break;
-            }
-        }
-        Ok(VarUint32(result))
+		let mut shift = 7;
+		loop {
+			let byte: u8 = Uint8::deserialize(reader)?.into();
+			result |= ((byte & 0x7F) as u32) << shift;
+			if shift >= 25 && (byte >> (32 - shift)) != 0 {
+				return Err(Error::InvalidVarUint32);
+			}
+			shift += 7;
+			if (byte & 0x80) == 0 {
+				break;
+			}
+		}
+		Ok(VarUint32(result))
 	}
 }
 

--- a/src/elements/primitives.rs
+++ b/src/elements/primitives.rs
@@ -41,6 +41,29 @@ impl TryFrom<usize> for VarUint32 {
 	}
 }
 
+impl VarUint32 {
+    /// Deserialize a LEB128‐encoded u32 with the leading byte already having been read.
+	pub fn deserialize_with_first<R: io::Read>(
+		reader: &mut R,
+		byte: u8,
+	) -> Result<Self, Error> {
+		let mut result = (byte & 0x7F) as u32;
+        let mut shift = 7;
+        loop {
+            let byte: u8 = Uint8::deserialize(reader)?.into();
+            result |= ((byte & 0x7F) as u32) << shift;
+            if shift >= 25 && (byte >> (32 - shift)) != 0 {
+                return Err(Error::InvalidVarUint32);
+            }
+            shift += 7;
+            if (byte & 0x80) == 0 {
+                break;
+            }
+        }
+        Ok(VarUint32(result))
+	}
+}
+
 impl Deserialize for VarUint32 {
 	type Error = Error;
 

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -344,7 +344,7 @@ impl Serialize for TypeSection {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
 		let counted_list =
-			CountedListWriter::<Type, _>(data.len(), data.into_iter().map(Into::into));
+			CountedListWriter::<Type, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -403,7 +403,7 @@ impl Serialize for ImportSection {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
 		let counted_list =
-			CountedListWriter::<ImportEntry, _>(data.len(), data.into_iter().map(Into::into));
+			CountedListWriter::<ImportEntry, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -491,7 +491,7 @@ impl Serialize for TableSection {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
 		let counted_list =
-			CountedListWriter::<TableType, _>(data.len(), data.into_iter().map(Into::into));
+			CountedListWriter::<TableType, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -534,7 +534,7 @@ impl Serialize for MemorySection {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
 		let counted_list =
-			CountedListWriter::<MemoryType, _>(data.len(), data.into_iter().map(Into::into));
+			CountedListWriter::<MemoryType, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -577,7 +577,7 @@ impl Serialize for GlobalSection {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
 		let counted_list =
-			CountedListWriter::<GlobalEntry, _>(data.len(), data.into_iter().map(Into::into));
+			CountedListWriter::<GlobalEntry, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -620,7 +620,7 @@ impl Serialize for ExportSection {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
 		let counted_list =
-			CountedListWriter::<ExportEntry, _>(data.len(), data.into_iter().map(Into::into));
+			CountedListWriter::<ExportEntry, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -663,7 +663,7 @@ impl Serialize for CodeSection {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
 		let counted_list =
-			CountedListWriter::<FuncBody, _>(data.len(), data.into_iter().map(Into::into));
+			CountedListWriter::<FuncBody, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -706,7 +706,7 @@ impl Serialize for ElementSection {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
 		let counted_list =
-			CountedListWriter::<ElementSegment, _>(data.len(), data.into_iter().map(Into::into));
+			CountedListWriter::<ElementSegment, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -749,7 +749,7 @@ impl Serialize for DataSection {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
 		let counted_list =
-			CountedListWriter::<DataSegment, _>(data.len(), data.into_iter().map(Into::into));
+			CountedListWriter::<DataSegment, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -343,8 +343,7 @@ impl Serialize for TypeSection {
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
-		let counted_list =
-			CountedListWriter::<Type, _>(data.len(), data.into_iter());
+		let counted_list = CountedListWriter::<Type, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -402,8 +401,7 @@ impl Serialize for ImportSection {
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
-		let counted_list =
-			CountedListWriter::<ImportEntry, _>(data.len(), data.into_iter());
+		let counted_list = CountedListWriter::<ImportEntry, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -490,8 +488,7 @@ impl Serialize for TableSection {
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
-		let counted_list =
-			CountedListWriter::<TableType, _>(data.len(), data.into_iter());
+		let counted_list = CountedListWriter::<TableType, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -533,8 +530,7 @@ impl Serialize for MemorySection {
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
-		let counted_list =
-			CountedListWriter::<MemoryType, _>(data.len(), data.into_iter());
+		let counted_list = CountedListWriter::<MemoryType, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -576,8 +572,7 @@ impl Serialize for GlobalSection {
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
-		let counted_list =
-			CountedListWriter::<GlobalEntry, _>(data.len(), data.into_iter());
+		let counted_list = CountedListWriter::<GlobalEntry, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -619,8 +614,7 @@ impl Serialize for ExportSection {
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
-		let counted_list =
-			CountedListWriter::<ExportEntry, _>(data.len(), data.into_iter());
+		let counted_list = CountedListWriter::<ExportEntry, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -662,8 +656,7 @@ impl Serialize for CodeSection {
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
-		let counted_list =
-			CountedListWriter::<FuncBody, _>(data.len(), data.into_iter());
+		let counted_list = CountedListWriter::<FuncBody, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -705,8 +698,7 @@ impl Serialize for ElementSection {
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
-		let counted_list =
-			CountedListWriter::<ElementSegment, _>(data.len(), data.into_iter());
+		let counted_list = CountedListWriter::<ElementSegment, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())
@@ -748,8 +740,7 @@ impl Serialize for DataSection {
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
 		let mut counted_writer = CountedWriter::new(writer);
 		let data = self.0;
-		let counted_list =
-			CountedListWriter::<DataSegment, _>(data.len(), data.into_iter());
+		let counted_list = CountedListWriter::<DataSegment, _>(data.len(), data.into_iter());
 		counted_list.serialize(&mut counted_writer)?;
 		counted_writer.done()?;
 		Ok(())

--- a/src/elements/types.rs
+++ b/src/elements/types.rs
@@ -226,13 +226,13 @@ impl Serialize for FunctionType {
 
 		let params_counted_list = CountedListWriter::<ValueType, _>(
 			self.params.len(),
-			self.params.into_iter().map(Into::into),
+			self.params.into_iter(),
 		);
 		params_counted_list.serialize(writer)?;
 
 		let results_counted_list = CountedListWriter::<ValueType, _>(
 			self.results.len(),
-			self.results.into_iter().map(Into::into),
+			self.results.into_iter(),
 		);
 		results_counted_list.serialize(writer)?;
 

--- a/src/elements/types.rs
+++ b/src/elements/types.rs
@@ -224,16 +224,12 @@ impl Serialize for FunctionType {
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
 		VarUint7::from(self.form).serialize(writer)?;
 
-		let params_counted_list = CountedListWriter::<ValueType, _>(
-			self.params.len(),
-			self.params.into_iter(),
-		);
+		let params_counted_list =
+			CountedListWriter::<ValueType, _>(self.params.len(), self.params.into_iter());
 		params_counted_list.serialize(writer)?;
 
-		let results_counted_list = CountedListWriter::<ValueType, _>(
-			self.results.len(),
-			self.results.into_iter(),
-		);
+		let results_counted_list =
+			CountedListWriter::<ValueType, _>(self.results.len(), self.results.into_iter());
 		results_counted_list.serialize(writer)?;
 
 		Ok(())

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -23,4 +23,5 @@ features = [
 	"sign_ext",
 	"bulk",
 	"multi_value",
+	"call_indirect_overlong",
 ]

--- a/testsuite/src/lib.rs
+++ b/testsuite/src/lib.rs
@@ -4,10 +4,12 @@ use std::ffi::OsStr;
 
 mod run;
 
-const BASIC_BLACKLIST: [&str; 2] = [
+const BASIC_BLACKLIST: [&str; 3] = [
 	// those use unsupported i32_trunc_sat_* instructions
 	"binary-leb128.wast",
 	"conversions.wast",
+	// this is valid with call_indirect_overlong enabled
+	"binary.wast",
 ];
 
 #[test_generator::test_resources("testsuite/spec/*.wast")]


### PR DESCRIPTION
Adds support for the ``call_indirect_overlong`` WASM feature, which should allow the parser to work with values emitted by the most recent rust toolchain. The feature is gated in ``Cargo.toml``, and is opt-in.