### PR TITLE
Bump crate version minor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-wasm"
-version = "0.46.2"
+version = "0.47.0"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Shulepov <s.pepyakin@gmail.com>", "Michał Papierski <michal@papierski.net>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Bumps the crate version to 0.47.0 from 0.46.2 to prepare for new release.